### PR TITLE
Visitor Creation Clean Up

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def all
     user = User.from_omniauth(request.env["omniauth.auth"])
     if user.persisted?
-      flash.notice = "Signed in as #{user.email}"
+      flash.notice = "Signed in as #{user.name}"
       sign_in_and_redirect user
     else
       session["devise.user_attributes"] = user.attributes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
   has_many :deals, through: :commitments
   has_many :comments, dependent: :destroy
   has_many :owned_deals, class_name: "Deal", foreign_key: 'owner_id'
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable, :omniauthable,
@@ -25,8 +25,7 @@ class User < ActiveRecord::Base
   end
 
   def self.from_omniauth(auth)
-    logger.info auth.inspect
-    where(email: auth.info.email).first || where(name: auth.info.nickname).first_or_create do |user|
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.provider = auth.provider
       user.uid = auth.uid
       user.name = auth.info.nickname

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ActiveRecord::Base
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.provider = auth.provider
       user.uid = auth.uid
-      user.name = auth.info.nickname
+      user.name = auth.info.first_name
       user.email = auth.info.email
     end
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,6 +8,8 @@ Devise.setup do |config|
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '776f32f2c859d103d576668db5b262e5a29cec0d1e64ffcda32fb881aa98b566fa425e432413f7933a9d509d54813dbc361eec7e9d42e01d30f0063cc88b5881'
 
+  config.omniauth :facebook, Rails.application.secrets.facebook_key, Rails.application.secrets.facebook_secret, scope: 'email', info_fields: 'email, name'
+
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
@@ -236,7 +238,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :facebook, Rails.application.secrets.facebook_key, Rails.application.secrets.facebook_secret, scope: 'email', info_fields: 'email, name'
+
   # config.omniauth :paypal, ENV['PAYPAL_ID'], ENV['PAYPAL_SECRET']
   # config.omniauth :linkedin, "APP_ID", "APP_SECRET"
   # ==> Warden configuration

--- a/test/features/authentication/visitor_can_create_account_test.rb
+++ b/test/features/authentication/visitor_can_create_account_test.rb
@@ -1,12 +1,12 @@
 require "test_helper"
 
-feature "Authentication::CanCreateAccount" do
+feature "Creating account" do
   before :each do
     visit root_path
     click_link('Sign up')
   end
 
-  scenario "with valid content" do
+  scenario "with valid content is successful" do
     fill_in "Name", with: "Person"
     fill_in 'Email', with: "new@example.com"
     fill_in 'Password', with: "password"
@@ -15,7 +15,7 @@ feature "Authentication::CanCreateAccount" do
     page.text.must_include "You have signed up successfully"
   end
 
-  scenario "without a valid formatted email" do
+  scenario "without a valid formatted email returns error" do
     fill_in "Name", with: "Person"
     fill_in 'Email', with: "user@example"
     fill_in 'Password', with: "password"
@@ -24,7 +24,7 @@ feature "Authentication::CanCreateAccount" do
     page.text.must_include "Email is invalid"
   end
 
-  scenario "without a valid password" do
+  scenario "without a valid password returns error" do
     fill_in "Name", with: "Person"
     fill_in 'Email', with: "user@example.com"
     fill_in 'Password', with: "password"
@@ -33,12 +33,21 @@ feature "Authentication::CanCreateAccount" do
     page.text.must_include "Password confirmation doesn't match Password"
   end
 
-  scenario "without a name" do
+  scenario "without a name returns error" do
     fill_in "Name", with: ""
     fill_in 'Email', with: "new@example.com"
     fill_in 'Password', with: "password"
     fill_in 'Password confirmation', with: "password"
     click_button('Sign up')
     page.text.must_include "Name can't be blank"
+  end
+
+  scenario "without a unique name returns error" do
+    fill_in "Name", with: "Joe User"
+    fill_in 'Email', with: "new@example.com"
+    fill_in 'Password', with: "password"
+    fill_in 'Password confirmation', with: "password"
+    click_button('Sign up')
+    page.text.must_include "Name has already been taken"
   end
 end


### PR DESCRIPTION
Changed facebook login name to first_name because nickname is not being found. Set uniqueness validation for user names. Re-worded account creation test for easier reading.
