### PR TITLE
Change facebook oauth name to first plus last. Stop flash from creating top margin.

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -10,7 +10,7 @@ html, body {
 .alert-box {
   position: relative;
   border-radius: 0 !important;
-  margin-bottom: 0;
+  margin: 0 !important;
   text-align: center;
   border: none !important;
   font-weight: bold !important;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -8,7 +8,9 @@ html, body {
 /* Flash message styles */
 
 .alert-box {
-  position: relative;
+  position: absolute;
+  top: 65px;
+  width: 100%;
   border-radius: 0 !important;
   margin: 0 !important;
   text-align: center;

--- a/app/assets/stylesheets/deals.scss
+++ b/app/assets/stylesheets/deals.scss
@@ -1,9 +1,5 @@
 /* Styles for Deal Show page */
 
-.deal-show {
-  margin-top: 75px;
-}
-
 .deal-large-image {
   width: 500px;
   height: 300px;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ActiveRecord::Base
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.provider = auth.provider
       user.uid = auth.uid
-      user.name = auth.info.nickname
+      user.name = auth.info.first_name + auth.info.last_name
       user.email = auth.info.email
     end
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '776f32f2c859d103d576668db5b262e5a29cec0d1e64ffcda32fb881aa98b566fa425e432413f7933a9d509d54813dbc361eec7e9d42e01d30f0063cc88b5881'
 
-  config.omniauth :facebook, Rails.application.secrets.facebook_key, Rails.application.secrets.facebook_secret, scope: 'email', info_fields: 'email, nickname'
+  config.omniauth :facebook, Rails.application.secrets.facebook_key, Rails.application.secrets.facebook_secret, scope: 'email', info_fields: 'email, first_name, last_name'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
Flash message no longer pushes page down. Top margin 75px removed from all pages since flash message was fixed.
